### PR TITLE
Include more files in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+graft tests
+include .travis.yml
+include LICENSE


### PR DESCRIPTION
tests and test-related files are useful for downstream OS packagers and
users that want to QA python packages.

Accordingly, include the tests directory and .travis.yml, which
includes the correct test invocation command, in the PyPI sdist via
MANIFEST.in.

In addition, it is best practice to include a LICENSE file with source
distributions, so accordingly, include it in MANIFEST.in

Note: tests module exclusion is already present in setup.py, so those
files are not _installed_, so it wasn't included in this PR.