### PR TITLE
Add Overleaf usage example to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -115,3 +115,5 @@ Now, you can use ``{lexer.py:JsxLexer -x}`` in front of your minted code blocks:
           }
         }
     \end{minted}
+    
+You can find an example of the lexer in use on Overleaf here: `https://www.overleaf.com/read/xvsytqzkvdjb`

--- a/README.rst
+++ b/README.rst
@@ -78,3 +78,40 @@ Now, you can use ``jsx`` in your code blocks::
       }
     }
     ```
+
+Usage with Overleaf
+-----------------
+
+First, add the minted package in your main file:
+
+.. code-block:: latex 
+
+    \usepackage{minted}
+
+Then, download the `lexer.py`_ file from this project, and place it in your root folder in Overleaf.
+
+.. _lexer.py: jsx/lexer.py
+
+Now, you can use ``{lexer.py:JsxLexer -x}`` in front of your minted code blocks:
+
+.. code-block:: latex
+
+    \begin{minted}{lexer.py:JsxLexer -x}
+        const BlogTitle = ({ children }) => (
+          <h3>{children}</h3>
+        );
+        // class component
+        class BlogPost extends React.Component {
+          renderTitle(title) {
+            return <BlogTitle>{title}</BlogTitle>
+          };
+          render() {
+            return (
+            <div className="blog-body">
+              {this.renderTitle(this.props.title)}
+              <p>{this.props.body}</p>
+            </div>
+            );
+          }
+        }
+    \end{minted}


### PR DESCRIPTION
Added Overleaf usage example to the README file, because it was a bit tricky to use it.
Now provide JSX syntax for the minted package on in latex/Overleaf.